### PR TITLE
Require 3.0.0, no longer set aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1"
+        "craftcms/cms": "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/commands/PublishAction.php
+++ b/src/commands/PublishAction.php
@@ -93,11 +93,6 @@ class PublishAction extends Action
 
     protected function adjustAliases()
     {
-        // Make 'web' aliases available in console
-        // Pre RC16
-        Craft::setAlias('@webroot', CRAFT_BASE_PATH . '/web');
-        Craft::setAlias('@web', '/');
-
         // Override where Yii should find its asset deps
         $libPath = Craft::getAlias('@lib');
         Craft::setAlias('@bower/bootstrap/dist', $libPath . '/bootstrap');


### PR DESCRIPTION
You shouldn't need to set the @web/@webroot aliases past RC16, since this was resolved: https://github.com/craftcms/cms/issues/2566